### PR TITLE
quick fix: Config is not in evaluation_proc

### DIFF
--- a/datasets/datasetParser/test_set_speech_all_distortion.py
+++ b/datasets/datasetParser/test_set_speech_all_distortion.py
@@ -9,7 +9,7 @@ r = os.path.dirname(git_root)
 from tools.file.wav import *
 
 from tools.file.path import find_and_build
-from evaluation_proc import Config
+from evaluation_proc.config import Config
 from progressbar import *
 
 ROOT = os.path.join(r,"voicefixer_main/datasets/se/TestSets")


### PR DESCRIPTION
https://github.com/haoheliu/voicefixer_main/blob/0c6f8b1f97e578f915d2ac45ae5d0799acdc346e/datasets/datasetParser/test_set_speech_all_distortion.py#L12

but evaluation_proc package (```__init__.py```) does not have Config.

I changed this code with this as below, and it works fine.

```python
from evaluation_proc.config import Config
```
